### PR TITLE
Convert any number to a word

### DIFF
--- a/pkg/geography/season/season.go
+++ b/pkg/geography/season/season.go
@@ -66,11 +66,7 @@ func (s Season) describe(c climate.Climate, r region.Region) (string, error) {
 		}
 	}
 
-	daylightHours, err := words.NumberToWord(s.DaylightHours)
-	if err != nil {
-		err = fmt.Errorf("failed to generate season description: %w", err)
-		return "", err
-	}
+	daylightHours := words.NumberToWord(s.DaylightHours)
 
 	description += ". There are " + daylightHours + " hours of daylight each day."
 

--- a/pkg/heraldry/charge/charge.go
+++ b/pkg/heraldry/charge/charge.go
@@ -95,11 +95,7 @@ func blazonForCharge(count int, singular string, plural string, descriptor strin
 		}
 
 	} else if count > 1 {
-		number, err := words.NumberToWord(count)
-		if err != nil {
-			err = fmt.Errorf("failed to generate blazon: %w", err)
-			return "", err
-		}
+		number := words.NumberToWord(count)
 		if descriptor != "" {
 			blazon += number + " " + plural + " " + descriptor + " " + tincture
 		} else {

--- a/pkg/words/words_test.go
+++ b/pkg/words/words_test.go
@@ -1,25 +1,88 @@
 package words
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestNumberToWord(t *testing.T) {
-	number := 0
-
-	result, err := NumberToWord(number)
-	if err != nil {
-		t.Error("failed to turn 0 into zero")
+	tests := []struct {
+		input int
+		want  string
+	}{
+		{
+			input: 0,
+			want:  "zero",
+		},
+		{
+			input: 5,
+			want:  "five",
+		},
+		{
+			input: 13,
+			want:  "thirteen",
+		},
+		{
+			input: 30,
+			want:  "thirty",
+		},
+		{
+			input: 56,
+			want:  "fifty-six",
+		},
+		{
+			input: 400,
+			want:  "four hundred",
+		},
+		{
+			input: 740,
+			want:  "seven hundred forty",
+		},
+		{
+			input: 839,
+			want:  "eight hundred thirty-nine",
+		},
+		{
+			input: 1000,
+			want:  "one thousand",
+		},
+		{
+			input: 3543,
+			want:  "three thousand five hundred forty-three",
+		},
+		{
+			input: 123_456,
+			want:  "one hundred twenty-three thousand four hundred fifty-six",
+		},
+		{
+			input: 5_000_000_000,
+			want:  "five billion",
+		},
+		{
+			input: 5_000_003_000,
+			want:  "five billion three thousand",
+		},
+		{
+			input: 1_000_000_000_000_000_000,
+			want:  "one quintillion",
+		},
+		{
+			input: 1<<63 - 1,
+			want: "nine quintillion two hundred twenty-three quadrillion three hundred seventy-two " +
+				"trillion thirty-six billion eight hundred fifty-four million seven hundred " +
+				"seventy-five thousand eight hundred seven",
+		},
+		{
+			input: -999,
+			want:  "minus nine hundred ninety-nine",
+		},
 	}
-	if result != "zero" {
-		t.Error("failed to turn 0 into zero")
-	}
-
-	number = 1
-
-	result, err = NumberToWord(number)
-	if err != nil {
-		t.Error("failed to turn 1 into one")
-	}
-	if result != "one" {
-		t.Error("failed to turn 1 into one")
+	for _, test := range tests {
+		t.Run(strconv.Itoa(test.input), func(t *testing.T) {
+			got := NumberToWord(test.input)
+			if !(test.want == got) {
+				t.Errorf("want: %s\ngot : %s", test.want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This is a rework of `NumberToWord` so that it is able to convert any number representable by a 64-bit integer into a word. This also means it doesn't return errors anymore.